### PR TITLE
docs: adjust action description and fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ jobs:
           path: ${{ steps.detekt.outputs.report }}
 ```
 
+See this action [releases][releases] or [tags][tags] for all available versions.
+
+[releases]: https://github.com/actungs/detekt-composite-action/releases
+[tags]: https://github.com/actungs/detekt-composite-action/tags
+
 ## Inputs
 
 These are the inputs, which can be given when using the action.

--- a/action.yaml
+++ b/action.yaml
@@ -2,7 +2,6 @@
 name: "Detekt Composite Action"
 description: |
   GitHub action for setting up and run detekt, a static code analysis for Kotlin.
-  See also [detekt documentation](https://detekt.dev/docs/intro) for more information.
 branding:
   icon: 'check'
   color: 'yellow'


### PR DESCRIPTION
Action description must not be longer than 125 chars. Otherwise, it is
not possible to publish the action to the GitHub Marketplace.
